### PR TITLE
add 自分のTODOのみ表示

### DIFF
--- a/backend/app/urls.py
+++ b/backend/app/urls.py
@@ -84,4 +84,6 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATICFILES_DIRS[0])
+    urlpatterns += static(
+        settings.STATIC_URL, document_root=settings.STATICFILES_DIRS[0]
+    )

--- a/backend/todo/admin.py
+++ b/backend/todo/admin.py
@@ -4,3 +4,4 @@ from django.contrib import admin
 from .models import TodoItem
 
 admin.site.register(TodoItem)
+

--- a/backend/todo/migrations/0001_initial.py
+++ b/backend/todo/migrations/0001_initial.py
@@ -1,11 +1,13 @@
 from django.db import migrations, models
 
+
 def set_default_user(apps, schema_editor):
-    User = apps.get_model('auth', 'User')
-    TodoItem = apps.get_model('todo', 'TodoItem')
+    User = apps.get_model("auth", "User")
+    TodoItem = apps.get_model("todo", "TodoItem")
     default_user = User.objects.first()  # デフォルトユーザーとして最初のユーザーを選択
     if default_user:  # デフォルトユーザーが存在する場合のみ更新
         TodoItem.objects.filter(user__isnull=True).update(user=default_user)
+
 
 class Migration(migrations.Migration):
 
@@ -29,8 +31,15 @@ class Migration(migrations.Migration):
                 ("title", models.CharField(max_length=255)),
                 ("description", models.TextField(blank=True, null=True)),
                 ("completed", models.BooleanField(default=False)),
-                ("user", models.ForeignKey(to='auth.User', on_delete=models.CASCADE, default=1)),  # デフォルトIDを設定
+                (
+                    "user",
+                    models.ForeignKey(
+                        to="auth.User", on_delete=models.CASCADE, default=1
+                    ),
+                ),  # デフォルトIDを設定
             ],
         ),
-        migrations.RunPython(set_default_user),  # マイグレーション後にデフォルトユーザーを設定
+        migrations.RunPython(
+            set_default_user
+        ),  # マイグレーション後にデフォルトユーザーを設定
     ]

--- a/backend/todo/migrations/0002_alter_todoitem_user.py
+++ b/backend/todo/migrations/0002_alter_todoitem_user.py
@@ -7,14 +7,18 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('auth', '0012_alter_user_first_name_max_length'),
-        ('todo', '0001_initial'),
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("todo", "0001_initial"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='todoitem',
-            name='user',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='todo_items', to='auth.user'),
+            model_name="todoitem",
+            name="user",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="todo_items",
+                to="auth.user",
+            ),
         ),
     ]

--- a/backend/todo/models.py
+++ b/backend/todo/models.py
@@ -1,13 +1,15 @@
 from django.db import models
 from django.contrib.auth.models import User
 
+
 def get_default_user():
-    return User.objects.get(username='hariken') 
+    return User.objects.get(username="hariken")
+
 
 # Create your models here.
 class TodoItem(models.Model):
     title = models.CharField(max_length=255)
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='todo_items')
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="todo_items")
     description = models.TextField(blank=True, null=True)
     completed = models.BooleanField(default=False)
 

--- a/backend/todo/tests/test_models.py
+++ b/backend/todo/tests/test_models.py
@@ -6,17 +6,22 @@ import pytest
 from django.utils import timezone
 from todo.models import TodoItem
 
+
 @pytest.mark.django_db
 def test_todo_item_creation():
-    todo = TodoItem.objects.create(title="Test Todo", description="Test Description", completed=False)
+    todo = TodoItem.objects.create(
+        title="Test Todo", description="Test Description", completed=False
+    )
     assert todo.title == "Test Todo"
     assert todo.description == "Test Description"
     assert todo.completed is False
+
 
 @pytest.mark.django_db
 def test_todo_item_str_method():
     todo = TodoItem.objects.create(title="Test Todo")
     assert str(todo) == "Test Todo"
+
 
 @pytest.mark.django_db
 def test_todo_item_default_values():

--- a/backend/todo/urls.py
+++ b/backend/todo/urls.py
@@ -1,5 +1,9 @@
 from django.urls import path
-from .views import TodoItemListCreateView, TodoItemRetrieveUpdateDestroyView
+from .views import (
+    TodoItemListCreateView,
+    TodoItemRetrieveUpdateDestroyView,
+    UserTodoListView,
+)
 
 urlpatterns = [
     path("todos/", TodoItemListCreateView.as_view(), name="todo-list-create"),
@@ -8,4 +12,5 @@ urlpatterns = [
         TodoItemRetrieveUpdateDestroyView.as_view(),
         name="todo-detail",
     ),
+    path("my-todos/", UserTodoListView.as_view(), name="user-todo-list"),
 ]

--- a/backend/todo/views.py
+++ b/backend/todo/views.py
@@ -21,7 +21,10 @@ class TodoItemRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = [IsAuthenticated]
 
 
-# @api_view(['GET'])
-# @permission_classes([IsAuthenticated])
-# def protected_view(request):
-#     return Response({"message": "This is a protected view!"})
+class UserTodoListView(generics.ListAPIView):
+    serializer_class = TodoItemSerializer
+    permission_classes = [IsAuthenticated]  # 認証済みユーザのみアクセス可能
+
+    def get_queryset(self):
+        # 認証されたユーザのTodoのみ取得
+        return TodoItem.objects.filter(user=self.request.user)


### PR DESCRIPTION
# 概要
自分のTodoのみ取得できるような実装を行った．

# 詳細
## 主な変更ファイルと変更の内容
- `backend/todo/views.py`: `UserTodoListView`というビューを新たに作成
- `backend/todo/urls.py`: 新たなビューを返すurl`my-todos`を作成

フォーマッターの適用も同時に行ったため変更状況がわかりづらくなってしまっています

## 動作の確認
1. https://github.com/hariken-1293/omnitech-drf-homework/pull/2 を参考に手順３まで実行する
2. 手順4を実行せず，`http://localhost:8000/api/my-todos/`にアクセスする

2では，Bearer Tokenで使用するため，アクセスキーを取得する必要があるが，取得時のログインしたユーザーのTODOが結果的に表示されることになる．

# 備考
- `/admin`では全てのTODOが表示される